### PR TITLE
[IMRPOVEMENT][BFW-130] amend .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -79,6 +79,14 @@ node_modules/
 .AppleDouble
 .LSOverride
 
+### VSCode ###
+.history
+.vscode
+
+### capitan ###
+/capitan/*.zip
+/capitan/_*_
+
 # Icon must end with two \r
 Icon
 


### PR DESCRIPTION
Ignores capitan specific build folders which should always be generated
freshly and not checked into any repository.

Ignores some VSCode specific files.