### PR TITLE
[IMPROVEMENT][BFW-129] remove roles from main and navigation

### DIFF
--- a/capitan/src/components/nav-main/nav-main.hbs
+++ b/capitan/src/components/nav-main/nav-main.hbs
@@ -1,4 +1,4 @@
 {{!-- components/nav-main --}}
-<nav class="nav-main" role="navigation">
+<nav class="nav-main">
 	Navi
 </nav>

--- a/capitan/src/templates/views/index.hbs
+++ b/capitan/src/templates/views/index.hbs
@@ -4,15 +4,15 @@
 
 	{{#*inline "main-block"}}
 
-		<main id="main" role="main">
+		<main id="main">
 			<h2>Styleguide</h2>
 			<ul>
 				<li><a href="styleguide.html">Styleguide</a></li>
 			</ul>
 
-            {{!-- <@views --}}{{!-- views@> --}}
+			{{!-- <@views --}}{{!-- views@> --}}
 
-        </main>
+		</main>
 
 	{{/inline}}
 


### PR DESCRIPTION
With HTML5, role="main" and role="nav" is communicated via the
respective semantic elements <main></main> and <nav></nav>. There
is no need to define roles for those elemens anymore.

(Also converted spaces to tab in index.hbs)